### PR TITLE
Build fix for VS 2019 - Missing <stdexcept> header

### DIFF
--- a/src_win/string_cast.h
+++ b/src_win/string_cast.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <stdexcept>
 #include <string>
 #include <windows.h>
 


### PR DESCRIPTION
VS 2019 cleaned up the standard headers, so `<stdexcept>` is no longer transiently included from `<string>`, which is needed to use `std::runtime_error`
https://devblogs.microsoft.com/cppblog/cpp17-20-features-and-fixes-in-vs-2019/

Same patch is needed in at least all repos that have `string_cast.h`.
A quick search on github gives me the following:
https://github.com/Nexus-Mods/node-ba2tk/blob/master/string_cast.h
https://github.com/Nexus-Mods/node-bsatk/blob/master/string_cast.h
https://github.com/Nexus-Mods/node-crash-dump/blob/master/src_win/string_cast.h
https://github.com/Nexus-Mods/node-esptk/blob/master/string_cast.h
https://github.com/Nexus-Mods/node-gamebryo-savegames/blob/master/src/string_cast.h
https://github.com/Nexus-Mods/node-loot/blob/master/src/string_cast.cpp
https://github.com/Nexus-Mods/node-native-errors/blob/master/src/string_cast.h
https://github.com/Nexus-Mods/node-turbowalk/blob/master/src/string_cast.h
https://github.com/Nexus-Mods/node-wholocks/blob/master/src_win/string_cast.h
https://github.com/Nexus-Mods/node-winapi-bindings/blob/master/src/string_cast.h
